### PR TITLE
Remove the <link>'s rel restrictions

### DIFF
--- a/src/HTMLExternalsAsset.js
+++ b/src/HTMLExternalsAsset.js
@@ -25,7 +25,7 @@ function _walk(walk, externals) {
   return htmlWalkFn => walk.call(this, node => {
     const src = node.attrs && (
       (node.tag === 'script' && node.attrs.src) ||
-      (node.tag === 'link' && node.attrs.rel === 'stylesheet' && node.attrs.href)
+      (node.tag === 'link' && node.attrs.href)
     );
 
     if (src && Object.keys(externals).find(external =>


### PR DESCRIPTION
I think to remove the `rel` restrictions can be better. Now I can make the template work.
```html
<!DOCTYPE html>
<html>
    <head>
        <title>title</title>
        <meta charset="utf-8">
        {% if favicon %}
        <link rel="icon" href="{{favicon}}">
        {% endif %}
    </head>
    <body>
        ...
    </body>
</html>
```